### PR TITLE
Added upload route and upload.html form

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -1,9 +1,14 @@
 from flask import Flask, render_template, request, redirect, session
 import sqlite3
 import hashlib
+import os
+from werkzeug.utils import secure_filename
 
 app = Flask(__name__)
 app.secret_key = '4bfd33473e4141b0533378fad588b6294409464d93d39810'
+UPLOAD_FOLDER = 'flask_app/uploads'
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+
 
 def init_db():
     conn = sqlite3.connect('users.db')
@@ -83,6 +88,27 @@ def dashboard():
     
     return render_template('dashboard.html', 
                           username=session.get('username'))
+@app.route('/upload', methods=['GET', 'POST'])
+def upload():
+    if 'user_id' not in session:
+        return redirect('/login')
+
+    if request.method == 'POST':
+        if 'file' not in request.files:
+            return "No file part"
+
+        file = request.files['file']
+
+        if file.filename == '':
+            return "No selected file"
+
+        filename = secure_filename(file.filename)
+        filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        file.save(filepath)
+
+        return redirect('/dashboard')
+
+    return render_template('upload.html')
 
 @app.route('/logout')
 def logout():

--- a/flask_app/templates/dashboard.html
+++ b/flask_app/templates/dashboard.html
@@ -1,3 +1,4 @@
 ﻿<h1>Welcome, {{ username }}!</h1>
 <p>You are logged in.</p>
+<a href="/upload">Upload media</a>
 <p><a href="/logout">Logout</a></p>

--- a/flask_app/templates/upload.html
+++ b/flask_app/templates/upload.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Upload Media</title>
+</head>
+<body>
+    <h2>Upload your media</h2>
+    <form method="POST" enctype="multipart/form-data">
+        <input type="file" name="file" required>
+        <br><br>
+        <button type="submit">Upload</button>
+    </form>
+    <a href="/dashboard">Back to dashboard</a>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a new feature that allows users to upload their own media to the website. 
- Added an `/upload` route in `app.py`
- Created `upload.html` template with a basic form
- Created `uploads` folder to store user files

This implements the issue:  #36 "As a user, I want to be able to upload my own media to the website."
